### PR TITLE
Make examples programs

### DIFF
--- a/examples
+++ b/examples
@@ -1,1 +1,0 @@
-tests/Examples

--- a/examples/InputObject.hs
+++ b/examples/InputObject.hs
@@ -1,17 +1,20 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
 
-module Examples.InputObject where
+-- | Demonstrate input object usage.
+module Main (main) where
 
 import Protolude hiding (Enum)
+
+import qualified Data.Aeson as Aeson
 
 import GraphQL
 import GraphQL.API
 import GraphQL.Resolver (Handler)
-import GraphQL.Value (FromValue)
+import GraphQL.Value (FromValue, toValue)
 
-data DogStuff = DogStuff { toy :: Text, likesTreats :: Bool } deriving (Show, Generic)
+data DogStuff = DogStuff { _toy :: Text, _likesTreats :: Bool } deriving (Show, Generic)
 instance FromValue DogStuff
 instance HasAnnotatedInputType DogStuff
 instance Defaultable DogStuff where
@@ -30,10 +33,6 @@ description (DogStuff toy likesTreats)
   | likesTreats = pure $ "likes treats and their favorite toy is a " <> toy
   | otherwise = pure $ "their favorite toy is a " <> toy
 
--- $setup
--- >>> import Data.Aeson (encode)
--- >>> import GraphQL.Value (ToValue(..))
-
 -- | Show input object usage
 --
 -- >>> response <- example "{ description(dogStuff: {toy: \"bone\", likesTreats: true}) }"
@@ -45,3 +44,11 @@ description (DogStuff toy likesTreats)
 -- {"data":{"description":"their favorite toy is a shoe"}}
 example :: Text -> IO Response
 example = interpretAnonymousQuery @Query root
+
+
+main :: IO ()
+main = do
+  response <- example "{ description(dogStuff: {toy: \"bone\", likesTreats: true}) }"
+  putStrLn $ Aeson.encode $ toValue response
+  response' <- example "{ description }"
+  putStrLn $ Aeson.encode $ toValue response'

--- a/examples/UnionExample.hs
+++ b/examples/UnionExample.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DataKinds #-}
-module Examples.UnionExample  where
+module Main (main) where
 
 import Protolude
+
+import qualified Data.Aeson as Aeson
 import GraphQL.API (Field, List, Object, Union)
-import GraphQL (Response, interpretAnonymousQuery)
+import GraphQL (interpretAnonymousQuery)
 import GraphQL.Resolver (Handler, (:<>)(..), unionValue)
+import GraphQL.Value (ToValue(..))
 
 -- Slightly reduced example from the spec
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
@@ -31,22 +34,9 @@ catOrDogList = pure $
        , unionValue @MiniDog miniDog
        ]
 
--- $setup
--- >>> import Data.Aeson (encode)
--- >>> import GraphQL.Value (ToValue(..))
-
--- | Show usage of a single unionValue
---
--- >>> response <- exampleQuery
--- >>> putStrLn $ encode $ toValue response
--- {"data":{"myPet":{"meowVolume":32,"name":"MonadicFelix"}}}
-exampleQuery :: IO Response
-exampleQuery = interpretAnonymousQuery @CatOrDog catOrDog "{ myPet { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
-
--- | 'unionValue' can be used in a list context
---
--- >>> response <- exampleListQuery
--- >>> putStrLn $ encode $ toValue response
--- {"data":{"pets":[{"meowVolume":32,"name":"Felix"},{"meowVolume":32,"name":"Mini"},{"barkVolume":100}]}}
-exampleListQuery :: IO Response
-exampleListQuery = interpretAnonymousQuery @CatOrDogList catOrDogList  "{ pets { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+main :: IO ()
+main = do
+  response <- interpretAnonymousQuery @CatOrDog catOrDog "{ myPet { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+  putStrLn $ Aeson.encode $ toValue response
+  response' <- interpretAnonymousQuery @CatOrDogList catOrDogList "{ pets { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+  putStrLn $ Aeson.encode $ toValue response'

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 244f60f8e2def55fa21d6d61b793b76e26ffbe6fea3b5a4b9fee01127d32358d
+-- hash: 6a38b887cec0d4a157469f5d73041fd16cb286d8f445f4e213c6f08965dbc563
 
 name:           graphql-api
 version:        0.3.0
@@ -74,6 +74,38 @@ library
       Paths_graphql_api
   default-language: Haskell2010
 
+executable input-object-example
+  main-is: InputObject.hs
+  hs-source-dirs:
+      examples
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
+  ghc-options: -Wall -fno-warn-redundant-constraints
+  build-depends:
+      aeson
+    , attoparsec
+    , base >=4.9 && <5
+    , exceptions
+    , graphql-api
+    , protolude >=0.2.1
+    , transformers
+  default-language: Haskell2010
+
+executable union-example
+  main-is: UnionExample.hs
+  hs-source-dirs:
+      examples
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
+  ghc-options: -Wall -fno-warn-redundant-constraints
+  build-depends:
+      aeson
+    , attoparsec
+    , base >=4.9 && <5
+    , exceptions
+    , graphql-api
+    , protolude >=0.2.1
+    , transformers
+  default-language: Haskell2010
+
 test-suite graphql-api-doctests
   type: exitcode-stdio-1.0
   main-is: Main.hs
@@ -118,8 +150,6 @@ test-suite graphql-api-tests
       ASTTests
       EndToEndTests
       EnumTests
-      Examples.InputObject
-      Examples.UnionExample
       ExampleSchema
       OrderedMapTests
       ResolverTests

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,23 @@ library:
     - QuickCheck
     - text
 
+executables:
+  input-object-example:
+    main: InputObject.hs
+    source-dirs: examples
+    other-modules: []
+    dependencies:
+      - aeson
+      - graphql-api
+
+  union-example:
+    main: UnionExample.hs
+    source-dirs: examples
+    other-modules: []
+    dependencies:
+      - aeson
+      - graphql-api
+
 tests:
   graphql-api-tests:
     main: Spec.hs

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -58,7 +58,7 @@ isHouseTrained dog (Just True) = houseTrainedElsewhere dog
 
 -- | Present 'ServerDog' for GraphQL.
 viewServerDog :: ServerDog -> Handler IO Dog
-viewServerDog dog@(ServerDog{..}) = pure $
+viewServerDog dog@ServerDog{..} = pure $
   pure name :<>
   pure (fmap pure nickname) :<>
   pure barkVolume :<>
@@ -79,7 +79,8 @@ mortgage = ServerDog
            }
 
 -- | Our server's internal representation of a 'Human'.
-data ServerHuman = ServerHuman Text deriving (Eq, Ord, Show)
+newtype ServerHuman = ServerHuman Text deriving (Eq, Ord, Show, Generic)
+
 
 -- | Present a 'ServerHuman' as a GraphQL 'Human'.
 viewServerHuman :: ServerHuman -> Handler IO Human

--- a/tests/ExampleSchema.hs
+++ b/tests/ExampleSchema.hs
@@ -249,6 +249,9 @@ type Human = Object "Human" '[Sentient]
 -- @
 data CatCommand = Jump deriving Generic
 
+instance Defaultable CatCommand where
+  defaultFor _ = empty
+
 instance GraphQLEnum CatCommand
 
 -- | A cat.

--- a/tests/ExampleSchema.hs
+++ b/tests/ExampleSchema.hs
@@ -108,6 +108,12 @@ import GraphQL.Value
 --     so it can be placed in a schema.
 data DogCommand = Sit | Down | Heel deriving (Show, Eq, Ord, Generic)
 
+instance Defaultable DogCommand where
+  -- Explicitly want no default for dogCommand
+  defaultFor (unName -> "dogCommand") = Nothing
+  -- DogCommand shouldn't be used elsewhere in schema, but who can say?
+  defaultFor _ = Nothing
+
 instance GraphQLEnum DogCommand
 
 -- TODO: Probably shouldn't have to do this for enums.
@@ -177,12 +183,6 @@ type Dog = Object "Dog" '[Pet]
    , Argument "atOtherHomes" (Maybe Bool) :> Field "isHouseTrained" Bool
    , Field "owner" Human
    ]
-
-instance Defaultable DogCommand where
-  -- Explicitly want no default for dogCommand
-  defaultFor (unName -> "dogCommand") = Nothing
-  -- DogCommand shouldn't be used elsewhere in schema, but who can say?
-  defaultFor _ = Nothing
 
 -- | Sentient beings have names.
 --

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -15,10 +15,6 @@ import qualified ValidationTests
 import qualified ValueTests
 import qualified EnumTests ()
 
--- import examples to ensure they compile
-import Examples.InputObject ()
-import Examples.UnionExample ()
-
 main :: IO ()
 main = do
   t <- sequence tests

--- a/tests/doctests/Main.hs
+++ b/tests/doctests/Main.hs
@@ -15,7 +15,5 @@ main = doctest $ ["-isrc"] <> options <> files
                  , "TypeApplications"
                  , "DataKinds"
                  ]
-    -- library code and examples
-    files = [ "src/"
-            , "tests/Examples/"
-            ]
+    -- library code
+    files = [ "src/" ]


### PR DESCRIPTION
We had a weird thing where top-level `examples` dir symlinked into tests, we used the test suite to compile the examples, and then used the doctests to check the examples worked.

At least one side effect of this is we get cabal warnings all the time:

```
Warning: There were multiple candidates for the Cabal entry " Examples.InputObject
         * /Users/jml/src/graphql-api/Examples/InputObject.hs
         picking: /Users/jml/src/graphql-api/tests/Examples/InputObject.hs

Warning: There were multiple candidates for the Cabal entry " Examples.UnionExample
         * /Users/jml/src/graphql-api/Examples/UnionExample.hs
         picking: /Users/jml/src/graphql-api/tests/Examples/UnionExample.hs
```

I've made the examples executables, which means they can be edited & run, which I think is a nice property. This lets us remove the symlink & doctest hackery.

In order to preserve the doctest coverage, I've translated the doctests into end-to-end tests. I think this has been a useful exercise, because it already demonstrates that our input object support / documentation is lacking (see comment on `DogStuff`).

It also paves the way for a ratcheted test coverage thing, which I'm quite keen to try.