### PR TITLE
Drop custom NonEmptyList type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 graphql-api changelog
 =====================
 
+0.4.0 (YYYY-MM-DD)
+==================
+
+* Schemas that have empty field lists or empty unions will fail much earlier
+
 0.3.0 (2018-02-08)
 ==================
 

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -27,7 +27,7 @@ import Protolude
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
-import GraphQL.API (HasObjectDefinition(..))
+import GraphQL.API (HasObjectDefinition(..), SchemaError(..))
 import GraphQL.Internal.Execution
   ( VariableValues
   , ExecutionError
@@ -52,7 +52,7 @@ import GraphQL.Internal.Output
 import GraphQL.Internal.Schema (Schema)
 import qualified GraphQL.Internal.Schema as Schema
 import GraphQL.Resolver (HasResolver(..), Result(..))
-import GraphQL.Value (Name, NameError, Value, pattern ValueObject)
+import GraphQL.Value (Name, Value, pattern ValueObject)
 
 -- | Errors that can happen while processing a query document.
 data QueryError
@@ -66,7 +66,7 @@ data QueryError
   -- | Validated, but failed during execution.
   | ExecutionError ExecutionError
   -- | Error in the schema.
-  | SchemaError NameError
+  | SchemaError SchemaError
   -- | Got a value that wasn't an object.
   | NonObjectResult Value
   deriving (Eq, Show)

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -14,6 +14,7 @@ module GraphQL.API
   , Defaultable(..)
   , HasObjectDefinition(..)
   , HasAnnotatedInputType(..)
+  , SchemaError(..)
   ) where
 
 import GraphQL.Internal.API
@@ -29,4 +30,5 @@ import GraphQL.Internal.API
   , Defaultable(..)
   , HasObjectDefinition(..)
   , HasAnnotatedInputType(..)
+  , SchemaError(..)
   )

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | Description: Fully realized GraphQL schema type system at the Haskell value level
@@ -21,7 +20,6 @@ module GraphQL.Internal.Schema
   , FieldDefinition(..)
   , Interfaces
   , InterfaceTypeDefinition(..)
-  , NonEmptyList(..)
   , ObjectTypeDefinition(..)
   , UnionTypeDefinition(..)
   -- ** Input types
@@ -63,9 +61,6 @@ makeSchema = Schema . getDefinedTypes
 -- | Find the type with the given name in the schema.
 lookupType :: Schema -> Name -> Maybe TypeDefinition
 lookupType (Schema schema) name = Map.lookup name schema
-
--- XXX: Use the built-in NonEmptyList in Haskell
-newtype NonEmptyList a = NonEmptyList [a] deriving (Eq, Ord, Show, Functor, Foldable)
 
 -- | A thing that defines types. Excludes definitions of input types.
 class DefinesTypes t where
@@ -141,7 +136,7 @@ instance DefinesTypes TypeDefinition where
       TypeDefinitionTypeExtension _ ->
         panic "TODO: we should remove the 'extend' behaviour entirely"
 
-data ObjectTypeDefinition = ObjectTypeDefinition Name Interfaces (NonEmptyList FieldDefinition)
+data ObjectTypeDefinition = ObjectTypeDefinition Name Interfaces (NonEmpty FieldDefinition)
                             deriving (Eq, Ord, Show)
 
 instance HasName ObjectTypeDefinition where
@@ -170,7 +165,7 @@ data ArgumentDefinition = ArgumentDefinition Name (AnnotatedType InputType) (May
 instance HasName ArgumentDefinition where
   getName (ArgumentDefinition name _ _) = name
 
-data InterfaceTypeDefinition = InterfaceTypeDefinition Name (NonEmptyList FieldDefinition)
+data InterfaceTypeDefinition = InterfaceTypeDefinition Name (NonEmpty FieldDefinition)
                                deriving (Eq, Ord, Show)
 
 instance HasName InterfaceTypeDefinition where
@@ -179,7 +174,7 @@ instance HasName InterfaceTypeDefinition where
 instance DefinesTypes InterfaceTypeDefinition where
   getDefinedTypes i@(InterfaceTypeDefinition name fields) = Map.singleton name (TypeDefinitionInterface i) <> foldMap getDefinedTypes fields
 
-data UnionTypeDefinition = UnionTypeDefinition Name (NonEmptyList ObjectTypeDefinition)
+data UnionTypeDefinition = UnionTypeDefinition Name (NonEmpty ObjectTypeDefinition)
                            deriving (Eq, Ord, Show)
 
 instance HasName UnionTypeDefinition where
@@ -237,7 +232,7 @@ newtype EnumValueDefinition = EnumValueDefinition Name
 instance HasName EnumValueDefinition where
   getName (EnumValueDefinition name) = name
 
-data InputObjectTypeDefinition = InputObjectTypeDefinition Name (NonEmptyList InputObjectFieldDefinition)
+data InputObjectTypeDefinition = InputObjectTypeDefinition Name (NonEmpty InputObjectFieldDefinition)
                                  deriving (Eq, Ord, Show)
 
 instance HasName InputObjectTypeDefinition where
@@ -305,4 +300,4 @@ doesFragmentTypeApply objectType fragmentType =
     _ -> False
   where
     implements (ObjectTypeDefinition _ interfaces _) int = int `elem` interfaces
-    branchOf obj (UnionTypeDefinition _ (NonEmptyList branches)) = obj `elem` branches
+    branchOf obj (UnionTypeDefinition _ branches) = obj `elem` branches

--- a/tests/SchemaTests.hs
+++ b/tests/SchemaTests.hs
@@ -24,7 +24,6 @@ import GraphQL.Internal.Schema
   , EnumValueDefinition(..)
   , FieldDefinition(..)
   , ObjectTypeDefinition(..)
-  , NonEmptyList(..)
   , InterfaceTypeDefinition(..)
   , AnnotatedType(..)
   , ListType(..)
@@ -47,15 +46,15 @@ tests = testSpec "Type" $ do
     getInterfaceDefinition @Sentient `shouldBe`
       Right (InterfaceTypeDefinition
         "Sentient"
-        (NonEmptyList [FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))]))
+        (FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString))) :| []))
   describe "full example" $
     it "encodes correctly" $ do
     getDefinition @Human `shouldBe`
       Right (ObjectTypeDefinition "Human"
         [ InterfaceTypeDefinition "Sentient" (
-            NonEmptyList [FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+            FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString))) :| [])
         ]
-        (NonEmptyList [FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))]))
+        (FieldDefinition "name" [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString))) :| []))
   describe "output Enum" $
     it "encodes correctly" $ do
     getAnnotatedType @(Enum "DogCommand" DogCommand) `shouldBe`
@@ -68,9 +67,7 @@ tests = testSpec "Type" $ do
     it "encodes correctly" $ do
     getAnnotatedType @CatOrDog `shouldBe`
       TypeNamed . DefinedType . TypeDefinitionUnion . UnionTypeDefinition "CatOrDog"
-        . NonEmptyList <$> sequence [ getDefinition @Cat
-                                    , getDefinition @Dog
-                                    ]
+        <$> sequence (getDefinition @Cat :| [getDefinition @Dog])
   describe "List" $
     it "encodes correctly" $ do
     getAnnotatedType @(List Int) `shouldBe` Right (TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))))


### PR DESCRIPTION
We added a `NonEmptyList` type *really* early in our explorations. Haskell already has one, so we should use that.

This has a knock-on: the type system now prevents us from constructing schemas with empty field lists, etc. This means we need to change error types a little.

I would have liked to write tests for this, but, you know how it is.