### PR TITLE
Variable definitions validation

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+-- This file has been generated from package.yaml by hpack version 0.28.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6a38b887cec0d4a157469f5d73041fd16cb286d8f445f4e213c6f08965dbc563
+-- hash: 6db006b020fe198ac64b8a50f8335017251389b7c34dfc553675e38eb001a428
 
 name:           graphql-api
 version:        0.3.0
@@ -23,7 +23,6 @@ license:        Apache
 license-file:   LICENSE.Apache-2.0
 build-type:     Simple
 cabal-version:  >= 1.10
-
 extra-source-files:
     CHANGELOG.rst
 

--- a/scripts/hpc-ratchet
+++ b/scripts/hpc-ratchet
@@ -35,11 +35,11 @@ In a just world, this would be a separate config file, or command-line arguments
 Each item represents the number of "things" we are OK with not being covered.
 """
 COVERAGE_TOLERANCE = {
-    ALTERNATIVES: 175,
+    ALTERNATIVES: 161,
     BOOLEANS: 8,
-    EXPRESSIONS: 1494,
-    LOCAL_DECLS: 15,
-    TOP_LEVEL_DECLS: 685,
+    EXPRESSIONS: 1416,
+    LOCAL_DECLS: 14,
+    TOP_LEVEL_DECLS: 669,
 }
 
 

--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -28,13 +28,15 @@ import GraphQL.Value
   , Object'(..)
   )
 import GraphQL.Internal.Output (GraphQLError(..))
+import GraphQL.Internal.Schema
+  ( AnnotatedType (TypeNonNull)
+  )
 import GraphQL.Internal.Validation
   ( Operation
   , QueryDocument(..)
   , VariableDefinition(..)
   , VariableValue
   , Variable
-  , GType(..)
   )
 
 -- | Get an operation from a GraphQL document

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -365,4 +365,4 @@ astAnnotationToSchemaAnnotation gtype schemaTypeName =
     AST.TypeNamed _ -> TypeNamed schemaTypeName
     AST.TypeList (AST.ListType astTypeName) -> TypeList (ListType $ astAnnotationToSchemaAnnotation astTypeName schemaTypeName)
     AST.TypeNonNull (AST.NonNullTypeNamed _) -> TypeNonNull (NonNullTypeNamed schemaTypeName)
-    AST.TypeNonNull (AST.NonNullTypeList (AST.ListType astTypeName)) -> astAnnotationToSchemaAnnotation astTypeName schemaTypeName
+    AST.TypeNonNull (AST.NonNullTypeList (AST.ListType astTypeName)) -> TypeNonNull (NonNullTypeList (ListType (astAnnotationToSchemaAnnotation astTypeName schemaTypeName)))

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -37,6 +37,7 @@ module GraphQL.Internal.Schema
   -- * The schema
   , Schema
   , makeSchema
+  , emptySchema
   , lookupType
   ) where
 
@@ -58,6 +59,9 @@ newtype Schema = Schema (Map Name TypeDefinition) deriving (Eq, Ord, Show)
 -- need to be reachable from a single root object. However, it's a start.
 makeSchema :: ObjectTypeDefinition -> Schema
 makeSchema = Schema . getDefinedTypes
+
+emptySchema :: Schema
+emptySchema = Schema (Map.empty :: (Map Name TypeDefinition))
 
 -- | Find the type with the given name in the schema.
 lookupType :: Schema -> Name -> Maybe TypeDefinition

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -305,6 +305,7 @@ doesFragmentTypeApply objectType fragmentType =
 
 -- | Convert the given TypeDefinition to an InputTypeDefinition if it's a valid InputTypeDefinition
 -- (because InputTypeDefinition is a subset of TypeDefinition)
+-- see <http://facebook.github.io/graphql/June2018/#sec-Input-and-Output-Types>
 getInputTypeDefinition :: TypeDefinition -> Maybe InputTypeDefinition
 getInputTypeDefinition td =
   case td of

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -341,9 +341,9 @@ builtinFromName typeName
 -- AST type annotations do not need any validation.
 -- GraphQL annotations are semantic decorations around type names to indicate type composition (list/non null).
 astAnnotationToSchemaAnnotation :: AST.GType -> a -> AnnotatedType a
-astAnnotationToSchemaAnnotation gtype schematn = 
+astAnnotationToSchemaAnnotation gtype schemaTypeName = 
   case gtype of
-    AST.TypeNamed _ -> TypeNamed schematn
-    AST.TypeList (AST.ListType asttn) -> TypeList (ListType $ astAnnotationToSchemaAnnotation asttn schematn)
-    AST.TypeNonNull (AST.NonNullTypeNamed _) -> TypeNonNull (NonNullTypeNamed schematn)
-    AST.TypeNonNull (AST.NonNullTypeList (AST.ListType asttn)) -> astAnnotationToSchemaAnnotation asttn schematn
+    AST.TypeNamed _ -> TypeNamed schemaTypeName
+    AST.TypeList (AST.ListType astTypeName) -> TypeList (ListType $ astAnnotationToSchemaAnnotation astTypeName schemaTypeName)
+    AST.TypeNonNull (AST.NonNullTypeNamed _) -> TypeNonNull (NonNullTypeNamed schemaTypeName)
+    AST.TypeNonNull (AST.NonNullTypeList (AST.ListType astTypeName)) -> astAnnotationToSchemaAnnotation astTypeName schemaTypeName

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -22,6 +22,7 @@ module GraphQL.Internal.Schema
   , InterfaceTypeDefinition(..)
   , ObjectTypeDefinition(..)
   , UnionTypeDefinition(..)
+  , ScalarTypeDefinition(..)
   -- ** Input types
   , InputType(..)
   , InputTypeDefinition(..)

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -34,6 +34,7 @@ module GraphQL.Internal.Schema
   , DefinesTypes(..)
   , doesFragmentTypeApply
   , getInputTypeDefinition
+  , builtinFromName
   -- * The schema
   , Schema
   , makeSchema
@@ -319,3 +320,16 @@ getInputTypeDefinition td =
     TypeDefinitionScalar itd -> Just (InputTypeDefinitionScalar itd) 
     TypeDefinitionEnum itd -> Just (InputTypeDefinitionEnum itd)
     _ -> Nothing
+
+-- | Create a 'Builtin' type from a 'Name'
+-- 
+-- Mostly used for the AST validation 
+-- theobat: There's probably a better way to do it but can't find it right now 
+builtinFromName :: Name -> Maybe Builtin
+builtinFromName typeName
+  | typeName == getName GInt = Just GInt
+  | typeName == getName GBool = Just GBool
+  | typeName == getName GString = Just GString
+  | typeName == getName GFloat = Just GFloat
+  | typeName == getName GID = Just GID
+  | otherwise = Nothing

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -33,6 +33,7 @@ module GraphQL.Internal.Schema
   , NonNullType(..)
   , DefinesTypes(..)
   , doesFragmentTypeApply
+  , getInputTypeDefinition
   -- * The schema
   , Schema
   , makeSchema
@@ -301,3 +302,13 @@ doesFragmentTypeApply objectType fragmentType =
   where
     implements (ObjectTypeDefinition _ interfaces _) int = int `elem` interfaces
     branchOf obj (UnionTypeDefinition _ branches) = obj `elem` branches
+
+-- | Convert the given TypeDefinition to an InputTypeDefinition if it's a valid InputTypeDefinition
+-- (because InputTypeDefinition is a subset of TypeDefinition)
+getInputTypeDefinition :: TypeDefinition -> Maybe InputTypeDefinition
+getInputTypeDefinition td =
+  case td of
+    TypeDefinitionInputObject itd -> Just (InputTypeDefinitionObject itd) 
+    TypeDefinitionScalar itd -> Just (InputTypeDefinitionScalar itd) 
+    TypeDefinitionEnum itd -> Just (InputTypeDefinitionEnum itd)
+    _ -> Nothing

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -60,6 +60,8 @@ newtype Schema = Schema (Map Name TypeDefinition) deriving (Eq, Ord, Show)
 makeSchema :: ObjectTypeDefinition -> Schema
 makeSchema = Schema . getDefinedTypes
 
+-- | Create an empty schema for testing purpose.
+--
 emptySchema :: Schema
 emptySchema = Schema (Map.empty :: (Map Name TypeDefinition))
 

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -309,8 +309,8 @@ doesFragmentTypeApply objectType fragmentType =
     implements (ObjectTypeDefinition _ interfaces _) int = int `elem` interfaces
     branchOf obj (UnionTypeDefinition _ branches) = obj `elem` branches
 
--- | Convert the given TypeDefinition to an InputTypeDefinition if it's a valid InputTypeDefinition
--- (because InputTypeDefinition is a subset of TypeDefinition)
+-- | Convert the given 'TypeDefinition' to an 'InputTypeDefinition' if it's a valid 'InputTypeDefinition'
+-- (because 'InputTypeDefinition' is a subset of 'TypeDefinition')
 -- see <http://facebook.github.io/graphql/June2018/#sec-Input-and-Output-Types>
 getInputTypeDefinition :: TypeDefinition -> Maybe InputTypeDefinition
 getInputTypeDefinition td =

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -179,7 +179,7 @@ data GType = TypeNamed NamedType
            | TypeNonNull NonNullType
            deriving (Eq, Ord, Show)
 
- -- | Get the name of the given GType.
+-- | Get the name of the given 'GType'.
 instance HasName GType where
   getName (TypeNamed (NamedType n)) = n
   getName (TypeList (ListType t)) = getName t

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -53,8 +53,11 @@ import Protolude
 import Test.QuickCheck (Arbitrary(..), listOf, oneof)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.Name (Name)
-
+import GraphQL.Internal.Name          
+  ( Name
+  , HasName(..)
+  )
+  
 -- * Documents
 
 -- | A 'QueryDocument' is something a user might send us.
@@ -175,6 +178,13 @@ data GType = TypeNamed NamedType
            | TypeList ListType
            | TypeNonNull NonNullType
            deriving (Eq, Ord, Show)
+
+ -- | Get the name of the given GType.
+instance HasName GType where
+  getName (TypeNamed (NamedType n)) = n
+  getName (TypeList (ListType t)) = getName t
+  getName (TypeNonNull (NonNullTypeNamed (NamedType n))) = n
+  getName (TypeNonNull (NonNullTypeList (ListType l))) = getName l
 
 newtype NamedType = NamedType Name deriving (Eq, Ord, Show)
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -58,6 +58,7 @@ module GraphQL.Internal.Validation
   , getResponseKey
   -- * Exported for testing
   , findDuplicates
+  , formatErrors
   ) where
 
 import Protolude hiding ((<>), throwE)
@@ -880,6 +881,11 @@ makeMap entries =
     Just dups -> throwErrors dups
 
 -- * Error handling
+
+-- | Utility function for tests, format ErrorTypes to their text representation
+-- returns a list of error messages
+formatErrors :: [ValidationError] -> [Text]
+formatErrors errors = formatError <$> errors
 
 -- | A 'Validator' is a value that can either be valid or have a non-empty
 -- list of errors.

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -687,9 +687,9 @@ validateVariableTypeBuiltin var tname
 astAnnotationToSchemaAnnotation :: AST.GType -> a -> AnnotatedType a
 astAnnotationToSchemaAnnotation gtype schematn = 
   case gtype of
-    AST.TypeNamed asttn -> TypeNamed schematn
+    AST.TypeNamed _ -> TypeNamed schematn
     AST.TypeList (AST.ListType asttn) -> astAnnotationToSchemaAnnotation asttn schematn
-    AST.TypeNonNull (AST.NonNullTypeNamed asttn) -> TypeNonNull (NonNullTypeNamed schematn)
+    AST.TypeNonNull (AST.NonNullTypeNamed _) -> TypeNonNull (NonNullTypeNamed schematn)
     AST.TypeNonNull (AST.NonNullTypeList (AST.ListType asttn)) -> astAnnotationToSchemaAnnotation asttn schematn
 
 -- | Ensure that a default value contains no variables.

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -633,7 +633,6 @@ validateArguments args = Arguments <$> mapErrors DuplicateArgument (makeMap [(na
 data VariableDefinition
   = VariableDefinition
     { variable :: Variable -- ^ The name of the variable
-    -- , variableType :: AST.GType -- ^ The type of the variable
     , variableType :: AnnotatedType InputType -- ^ The type of the variable
     , defaultValue :: Maybe Value -- ^ An optional default value for the variable
     } deriving (Eq, Ord, Show)

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -181,7 +181,7 @@ validateOperations schema fragments ops = do
   traverse validateNode deduped
   where
     validateNode (operationType, AST.Node _ vars directives ss) =
-      operationType <$> lift ((validateVariableDefinitions schema) vars)
+      operationType <$> lift (validateVariableDefinitions schema vars)
                     <*> lift (validateDirectives directives)
                     <*> validateSelectionSet schema fragments ss
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -89,6 +89,7 @@ import GraphQL.Internal.Schema
   , NonNullType(NonNullTypeNamed)
   , getInputTypeDefinition
   , builtinFromName
+  , astAnnotationToSchemaAnnotation
   )
 import GraphQL.Value
   ( Value
@@ -687,15 +688,6 @@ validateVariableTypeBuiltin var typeName =
   case builtinFromName typeName of
     Nothing -> throwE (VariableTypeNotFound var typeName)
     Just builtin -> pure (BuiltinInputType builtin)
-
--- | simple translation between ast annotation types and schema annotation types
-astAnnotationToSchemaAnnotation :: AST.GType -> a -> AnnotatedType a
-astAnnotationToSchemaAnnotation gtype schematn = 
-  case gtype of
-    AST.TypeNamed _ -> TypeNamed schematn
-    AST.TypeList (AST.ListType asttn) -> astAnnotationToSchemaAnnotation asttn schematn
-    AST.TypeNonNull (AST.NonNullTypeNamed _) -> TypeNonNull (NonNullTypeNamed schematn)
-    AST.TypeNonNull (AST.NonNullTypeList (AST.ListType asttn)) -> astAnnotationToSchemaAnnotation asttn schematn
 
 -- | Ensure that a default value contains no variables.
 validateDefaultValue :: AST.DefaultValue -> Validation Value

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -82,11 +82,8 @@ import GraphQL.Internal.Schema
   , doesFragmentTypeApply
   , lookupType
   , AnnotatedType(..)
-  , InputType
   , InputType (BuiltinInputType, DefinedInputType) 
-  , Builtin (..)
-  , AnnotatedType (TypeNamed, TypeNonNull)
-  , NonNullType(NonNullTypeNamed)
+  , AnnotatedType
   , getInputTypeDefinition
   , builtinFromName
   , astAnnotationToSchemaAnnotation

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -211,3 +211,38 @@ tests = testSpec "AST" $ do
                             ]))
                      ]
       parsed `shouldBe` expected
+    it "parses anonymous query with variable annotation" $ do
+      let query = [r|
+                    query ($atOtherHomes: [Home!]) {
+                      dog {
+                        isHousetrained(atOtherHomes: $atOtherHomes)
+                      }
+                    }
+                    |]
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
+                     [ AST.DefinitionOperation
+                         (AST.Query
+                           (AST.Node Nothing
+                            [ AST.VariableDefinition
+                                (AST.Variable "atOtherHomes")
+                                (AST.TypeList 
+                                  (AST.ListType 
+                                    (AST.TypeNonNull
+                                      (AST.NonNullTypeNamed (AST.NamedType "Home"))
+                                    )
+                                  )
+                                )
+                                Nothing
+                            ] []
+                            [ AST.SelectionField
+                                (AST.Field Nothing dog [] []
+                                 [ AST.SelectionField
+                                     (AST.Field Nothing "isHousetrained"
+                                      [ AST.Argument "atOtherHomes"
+                                          (AST.ValueVariable (AST.Variable "atOtherHomes"))
+                                      ] [] [])
+                                 ])
+                            ]))
+                     ]
+      parsed `shouldBe` expected

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -277,3 +277,32 @@ tests = testSpec "AST" $ do
                             ]))
                      ]
       parsed `shouldBe` expected
+    it "parses anonymous query with fragment" $ do
+      -- keys are not quoted for inline objects
+      let query = [r|
+                    fragment dogTest on Dog {
+                      name
+                    }
+                    query {
+                      dog {
+                        ...dogTest
+                      }
+                    }
+                    |]
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
+                     [(AST.DefinitionFragment (AST.FragmentDefinition "dogTest"
+                        (AST.NamedType "Dog") [] [
+                          AST.SelectionField (AST.Field Nothing "name" [] [] [])
+                        ])),
+                        (AST.DefinitionOperation
+                         (AST.Query
+                           (AST.Node Nothing
+                            [] []
+                            [AST.SelectionField
+                              (AST.Field Nothing dog [] []
+                                [AST.SelectionFragmentSpread (AST.FragmentSpread "dogTest" [])
+                                ])    
+                            ])))
+                     ]
+      parsed `shouldBe` expected

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -246,3 +246,34 @@ tests = testSpec "AST" $ do
                             ]))
                      ]
       parsed `shouldBe` expected
+    it "parses anonymous query with inline argument as a list of object" $ do
+      -- keys are not quoted for inline objects
+      let query = [r|
+                    query {
+                      dog {
+                        isHousetrained(atOtherHomes: [{testKey: 123, anotherKey: "string"}])
+                      }
+                    }
+                    |]
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
+                     [ AST.DefinitionOperation
+                         (AST.Query
+                           (AST.Node Nothing
+                            [] []
+                            [ AST.SelectionField
+                                (AST.Field Nothing dog [] []
+                                 [ AST.SelectionField
+                                     (AST.Field Nothing "isHousetrained"
+                                      [ AST.Argument "atOtherHomes"
+                                          (AST.ValueList (AST.ListValue [
+                                            (AST.ValueObject (AST.ObjectValue [
+                                              (AST.ObjectField "testKey" (AST.ValueInt 123)),
+                                              (AST.ObjectField "anotherKey" (AST.ValueString (AST.StringValue "string")))
+                                            ]))
+                                          ]))
+                                      ] [] [])
+                                 ])
+                            ]))
+                     ]
+      parsed `shouldBe` expected

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -115,6 +115,16 @@ tests = testSpec "AST" $ do
                      ]
       parsed `shouldBe` expected
 
+    it "errors on missing selection set" $ do
+      let query = [r|query {
+                       dog {
+                         
+                       }
+                     }|]
+      let Left parsed = parseOnly Parser.queryDocument query
+      -- this is not very explicit
+      parsed `shouldBe` "query document error! > definition error!: string"
+
     it "parses invalid documents" $ do
       let query = [r|{
                        dog {
@@ -246,7 +256,7 @@ tests = testSpec "AST" $ do
                             ]))
                      ]
       parsed `shouldBe` expected
-    it "parses anonymous query with inline argument as a list of object" $ do
+    it "parses anonymous query with inline argument (List, Object, Enum, String, Number)" $ do
       -- keys are not quoted for inline objects
       let query = [r|
                     query {

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -431,7 +431,6 @@ tests = testSpec "End-to-end tests" $ do
               , "errors" .=
                 [
                   object
-                  -- TODO: cf previous test case
                   [ "message" .= ("Could not coerce Name {unName = \"dogCommand\"} to valid value: ValueScalar' ConstNull not an enum: [Right (Name {unName = \"Sit\"}),Right (Name {unName = \"Down\"}),Right (Name {unName = \"Heel\"})]" :: Text)
                   ]
                 ]

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -472,7 +472,6 @@ tests = testSpec "End-to-end tests" $ do
               ]
         toJSON (toValue response) `shouldBe` expected
       it "Errors when non-null variable is not provided" $ do
-        let Right varName = makeName "whichCommand"
         response <- executeQuery  @QueryRoot (rootHandler mortgage) annotatedQuery Nothing mempty
         let expected =
               object

--- a/tests/SchemaTests.hs
+++ b/tests/SchemaTests.hs
@@ -14,6 +14,7 @@ import GraphQL.API
   , getAnnotatedInputType
   , getDefinition
   )
+import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.API
   ( getAnnotatedType
   , getFieldDefinition
@@ -40,6 +41,7 @@ import GraphQL.Internal.Schema
   , InputType(..)
   , getInputTypeDefinition
   , builtinFromName
+  , astAnnotationToSchemaAnnotation
   )
 import ExampleSchema
 
@@ -109,3 +111,23 @@ tests = testSpec "Type" $ do
     builtinFromName "Float" `shouldBe` Just GFloat
     builtinFromName "ID" `shouldBe` Just GID
     builtinFromName "RANDOMSTRING" `shouldBe` Nothing
+  describe "Annotations from AST" $
+    it "annotation like [[ScalarType!]]!" $ do
+    let typeDefinitionScalar = (TypeDefinitionScalar (ScalarTypeDefinition "ScalarType"))
+    astAnnotationToSchemaAnnotation (
+      AST.TypeNonNull (
+        AST.NonNullTypeList (
+          AST.ListType (
+            AST.TypeList (
+              AST.ListType (
+                AST.TypeNonNull (
+                  AST.NonNullTypeNamed (AST.NamedType "ScalarType")
+      ))))))) typeDefinitionScalar `shouldBe` (
+        TypeNonNull (
+          NonNullTypeList (
+            ListType (
+              TypeList (
+                ListType (
+                  TypeNonNull (
+                    NonNullTypeNamed typeDefinitionScalar
+        )))))))

--- a/tests/SchemaTests.hs
+++ b/tests/SchemaTests.hs
@@ -90,7 +90,6 @@ tests = testSpec "Type" $ do
      , EnumValueDefinition "Down"
      , EnumValueDefinition "Heel"
      ]))
-    -- it "InputObject" $ do
     getInputTypeDefinition (TypeDefinitionInputObject (InputObjectTypeDefinition  "Human"
      (InputObjectFieldDefinition "name" (TypeNonNull (NonNullTypeNamed (BuiltinInputType GString))) Nothing :| [])
      )) `shouldBe` Just (InputTypeDefinitionObject (InputObjectTypeDefinition "Human"
@@ -110,4 +109,3 @@ tests = testSpec "Type" $ do
     builtinFromName "Float" `shouldBe` Just GFloat
     builtinFromName "ID" `shouldBe` Just GID
     builtinFromName "RANDOMSTRING" `shouldBe` Nothing
-

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -14,7 +14,7 @@ import qualified Data.Set as Set
 
 import GraphQL.Internal.Name (Name)
 import qualified GraphQL.Internal.Syntax.AST as AST
-import GraphQL.Internal.Schema (Schema, emptySchema)
+import GraphQL.Internal.Schema (emptySchema, Schema)
 import GraphQL.Internal.Validation
   ( ValidationError(..)
   , findDuplicates

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
 
 -- | Tests for query validation.
 module ValidationTests (tests) where
@@ -11,8 +12,9 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Internal.Name (Name)
+import qualified Data.Map as Map
 import qualified GraphQL.Internal.Syntax.AST as AST
-import GraphQL.Internal.Schema (Schema)
+import GraphQL.Internal.Schema (Schema, emptySchema)
 import GraphQL.Internal.Validation
   ( ValidationError(..)
   , findDuplicates
@@ -27,11 +29,11 @@ someName = "name"
 
 dog :: Name
 dog = "dog"
-
+   
 -- | Schema used for these tests. Since none of them do type-level stuff, we
 -- don't need to define it.
 schema :: Schema
-schema = panic "schema evaluated. We weren't expecting that."
+schema = emptySchema
 
 tests :: IO TestTree
 tests = testSpec "Validation" $ do

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -12,7 +12,6 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Internal.Name (Name)
-import qualified Data.Map as Map
 import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Schema (Schema, emptySchema)
 import GraphQL.Internal.Validation
@@ -54,7 +53,7 @@ tests = testSpec "Validation" $ do
       let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   (AST.Query
-                    (AST.Node (Nothing) [] []
+                    (AST.Node Nothing [] []
                       [ AST.SelectionField
                         (AST.Field Nothing dog [] []
                           [ AST.SelectionField (AST.Field Nothing someName [] [] [])

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -29,7 +29,7 @@ someName = "name"
 
 dog :: Name
 dog = "dog"
-   
+
 -- | Schema used for these tests. Since none of them do type-level stuff, we
 -- don't need to define it.
 schema :: Schema
@@ -160,29 +160,6 @@ tests = testSpec "Validation" $ do
                        ]))
                 ]
       getErrors schema doc `shouldBe` [UnusedVariables (Set.fromList [AST.Variable "atOtherHomes"])]
-
-    -- This test case should fail. FIXME ! + another one: mismatch between variable and default value
-    it "Detects type mismatch between variables and arguments" $ do
-      let doc = AST.QueryDocument
-                [ AST.DefinitionOperation
-                    (AST.Query
-                      (AST.Node Nothing
-                       [ AST.VariableDefinition
-                           (AST.Variable "atOtherHomes")
-                           (AST.TypeNamed (AST.NamedType "String"))
-                           Nothing
-                       ] []
-                       [ AST.SelectionField
-                           (AST.Field Nothing dog [] []
-                            [ AST.SelectionField
-                                (AST.Field Nothing "isHousetrained"
-                                 [ AST.Argument "atOtherHomes"
-                                     (AST.ValueVariable (AST.Variable "atOtherHomes"))
-                                 ] [] [])
-                            ])
-                       ]))
-                ]
-      getErrors schema doc `shouldBe` []
 
   describe "findDuplicates" $ do
     prop "returns empty on unique lists" $ do


### PR DESCRIPTION
This PR is a required step towards the resolution of #145. It improves the validation of type declaration in variable definitions. For instance it validates the fact that when a document contains $myVariable: MyVar, then the MyVar type actually exists in the schema and it's an InputType.

Remaining tasks:
- [x] test cases for the new ValidationErrors 
- [x] fix current broken EndToEnd tests

PS: this is my first "real" attempt to write haskell so please, any insight would be greatly appreciated.

**Edit: I added DefinesTypes instances on arguments because failing tests were simply not finding their argument types in the schema (schema in the sense of what is returned by makeSchema)**