### PR TITLE
Support __typename introspection

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6db006b020fe198ac64b8a50f8335017251389b7c34dfc553675e38eb001a428
+-- hash: 24bc26dbd1f77e90690a71683ae20372d13f4729b6073940a17679e5bc18c609
 
 name:           graphql-api
 version:        0.3.0
@@ -133,6 +133,7 @@ test-suite graphql-api-tests
   build-depends:
       QuickCheck
     , aeson
+    , aeson-qq
     , attoparsec
     , base >=4.9 && <5
     , containers
@@ -144,6 +145,7 @@ test-suite graphql-api-tests
     , raw-strings-qq
     , tasty
     , tasty-hspec
+    , text
     , transformers
   other-modules:
       ASTTests

--- a/package.yaml
+++ b/package.yaml
@@ -71,8 +71,10 @@ tests:
       - hspec
       - QuickCheck
       - raw-strings-qq
+      - aeson-qq
       - tasty
       - tasty-hspec
+      - text
       - directory
 
   graphql-api-doctests:


### PR DESCRIPTION
Hey y'all - big fan of the project. Thanks for your work on it.

I'm currently working on using this as the backend for an Apollo client, which seems to assume that all types will at least support the `__typename` introspection field for client-side caching purposes. I've been faking it by manually adding an explicit `__typename` field to every type, but wanted to take a swing at implementing this properly and learning some of the internals and type machinery here.

I added a few tests, but if there's anything else I can do to improve this PR (implementation, documentation, or otherwise) please let me know.

For what it's worth, I'd be interested in continuing to contribute to this project, and would welcome any suggestions for how best to do so. I'm going to explore what I can implement in terms of supporting http://facebook.github.io/graphql/June2018/#sec-Schema-Introspection currently, though it looks like it may require some non-trivial internal changes to support e.g. querying the fields of input objects.