### PR TITLE
Simplify GenericInputObjectFieldDefinitions

### DIFF
--- a/scripts/hpc-ratchet
+++ b/scripts/hpc-ratchet
@@ -37,8 +37,8 @@ Each item represents the number of "things" we are OK with not being covered.
 COVERAGE_TOLERANCE = {
     ALTERNATIVES: 161,
     BOOLEANS: 8,
-    EXPRESSIONS: 1416,
-    LOCAL_DECLS: 14,
+    EXPRESSIONS: 1412,
+    LOCAL_DECLS: 13,
     TOP_LEVEL_DECLS: 669,
 }
 


### PR DESCRIPTION
We simplify `GenericInputObjectFieldDefinitions` by using
tree-recursion, resulting in better error messages. Example
code to reproduce below, where the 'true' error is usage of
lists.

```hs
data family Test :: Nat -> Type
data instance Test 1 = Test
  { testField1 :: Int32
  , testField2 :: Text
  , testField3 :: Text
  , testField4 :: [Int32]
  } deriving (Show, Generic)
instance HasAnnotatedInputType Test
```

Before
```
        • No instance for (GraphQL.Internal.API.GenericInputObjectFieldDefinitions
                             ((S1
                                 ('MetaSel
                                    ('Just "testField1")
                                    'NoSourceUnpackedness
                                    'NoSourceStrictness
                                    'DecidedLazy)
                                 (Rec0 Int32)
                               :*: S1
                                     ('MetaSel
                                        ('Just "testField2")
                                        'NoSourceUnpackedness
                                        'NoSourceStrictness
                                        'DecidedLazy)
                                     (Rec0 Text))
                              :*: (S1
                                     ('MetaSel
                                        ('Just "testField3")
                                        'NoSourceUnpackedness
                                        'NoSourceStrictness
                                        'DecidedLazy)
                                     (Rec0 Text)
                                   :*: S1
                                         ('MetaSel
                                            ('Just "testField4")
                                            'NoSourceUnpackedness
                                            'NoSourceStrictness
                                            'DecidedLazy)
                                         (Rec0 [Int32]))))
            arising from a use of ‘GraphQL.Internal.API.$dmgetAnnotatedInputType’
        • In the expression:
            GraphQL.Internal.API.$dmgetAnnotatedInputType @(Test 1)
          In an equation for ‘QL.getAnnotatedInputType’:
              QL.getAnnotatedInputType
                = GraphQL.Internal.API.$dmgetAnnotatedInputType @(Test 1)
          In the instance declaration for ‘QL.HasAnnotatedInputType (Test 1)’
       |
    72 | instance QL.HasAnnotatedInputType (Test 1)
       |
```

After
```
    • No instance for (QL.HasAnnotatedInputType [Int32])
      arising from a use of ‘GraphQL.Internal.API.$dmgetAnnotatedInputType’
    • In the expression:
        GraphQL.Internal.API.$dmgetAnnotatedInputType @(Test 1)
      In an equation for ‘QL.getAnnotatedInputType’:
          QL.getAnnotatedInputType
            = GraphQL.Internal.API.$dmgetAnnotatedInputType @(Test 1)
      In the instance declaration for ‘QL.HasAnnotatedInputType (Test 1)’
    |
72  | instance QL.HasAnnotatedInputType (Test 1)
    |
```