### PR TITLE
[WIP] Adding Position Annotation

### DIFF
--- a/src/GraphQL/Internal/Syntax/.#AST.hs
+++ b/src/GraphQL/Internal/Syntax/.#AST.hs
@@ -1,0 +1,1 @@
+jinxuanzhu@Jinxuans-MacBook-Pro.local.83087

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -53,17 +53,20 @@ import Protolude
 import Test.QuickCheck (Arbitrary(..), listOf, oneof)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.Name          
+import GraphQL.Internal.Name
   ( Name
   , HasName(..)
   )
-  
+
 -- * Documents
 
 -- | A 'QueryDocument' is something a user might send us.
 --
 -- https://facebook.github.io/graphql/#sec-Language.Query-Document
-newtype QueryDocument = QueryDocument { getDefinitions :: [Definition] } deriving (Eq,Show)
+data QueryDocument = QueryDocument {
+  getDefinitions :: [Definition]
+  , position :: (Int, Int)
+  } deriving (Eq,Show)
 
 data Definition = DefinitionOperation OperationDefinition
                 | DefinitionFragment  FragmentDefinition

--- a/src/GraphQL/Internal/Syntax/Encoder.hs
+++ b/src/GraphQL/Internal/Syntax/Encoder.hs
@@ -18,7 +18,7 @@ import GraphQL.Internal.Name (unName)
 -- * Document
 
 queryDocument :: AST.QueryDocument -> Text
-queryDocument (AST.QueryDocument defs) = (`snoc` '\n') . mconcat $ definition <$> defs
+queryDocument (AST.QueryDocument defs _) = (`snoc` '\n') . mconcat $ definition <$> defs
 
 definition :: AST.Definition -> Text
 definition (AST.DefinitionOperation x) = operationDefinition x

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -139,7 +139,7 @@ type Operations value = Map (Maybe Name) (Operation value)
 -- The document is known to be syntactically valid, as we've got its AST.
 -- Here, we confirm that it's semantically valid (modulo types).
 validate :: Schema -> AST.QueryDocument -> Either (NonEmpty ValidationError) (QueryDocument VariableValue)
-validate schema (AST.QueryDocument defns) = runValidator $ do
+validate schema (AST.QueryDocument defns _) = runValidator $ do
   let (operations, fragments) = splitBy splitDefns defns
   let (anonymous, maybeNamed) = splitBy splitOps operations
   (frags, visitedFrags) <- resolveFragmentDefinitions =<< validateFragmentDefinitions schema fragments

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack-8.2.yaml

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -93,7 +93,7 @@ tests = testSpec "AST" $ do
                              [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                              ])
                          ])
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
 
     it "parses anonymous query documents" $ do
@@ -112,7 +112,7 @@ tests = testSpec "AST" $ do
                                [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                                ])
                            ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
 
     it "errors on missing selection set" $ do
@@ -159,7 +159,7 @@ tests = testSpec "AST" $ do
                                ])
                             ])
                          ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
 
     it "includes variable definitions" $ do
@@ -189,7 +189,7 @@ tests = testSpec "AST" $ do
                                       ] [] [])
                                  ])
                             ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
 
     it "parses anonymous query with variables" $ do
@@ -219,7 +219,7 @@ tests = testSpec "AST" $ do
                                       ] [] [])
                                  ])
                             ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
     it "parses anonymous query with variable annotation" $ do
       let query = [r|
@@ -254,7 +254,7 @@ tests = testSpec "AST" $ do
                                       ] [] [])
                                  ])
                             ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
     it "parses anonymous query with inline argument (List, Object, Enum, String, Number)" $ do
       -- keys are not quoted for inline objects
@@ -285,7 +285,7 @@ tests = testSpec "AST" $ do
                                       ] [] [])
                                  ])
                             ]))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected
     it "parses anonymous query with fragment" $ do
       -- keys are not quoted for inline objects
@@ -314,5 +314,5 @@ tests = testSpec "AST" $ do
                                 [AST.SelectionFragmentSpread (AST.FragmentSpread "dogTest" [])
                                 ])    
                             ])))
-                     ]
+                     ] (0, 0)
       parsed `shouldBe` expected


### PR DESCRIPTION
There will be a big change if we want to add position annotation as discussed in https://github.com/haskell-graphql/graphql-api/issues/75

We used to have `schema :: a -> AST`, then it will be `schema :: a -> (Int, Int) -> AST`