### PR TITLE
[WIP] Support for standard JSON post request

### DIFF
--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -18,6 +18,7 @@ module GraphQL.Internal.Execution
 
 import Protolude
 
+import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
 import GraphQL.Value
   ( Name
@@ -109,3 +110,7 @@ instance GraphQLError ExecutionError where
 -- GraphQL allows the values of variables to be specified, but doesn't provide
 -- a way for doing so in the language.
 type VariableValues = Map Variable Value
+
+-- | The raw (textual and/or aeson based) version of the 'Request' datatype.
+-- See <http://graphql.org/learn/serving-over-http/#post-request>.
+data RawPostRequest = RawPostRequest Text (Maybe Text) Aeson.Object deriving (Eq, Show)


### PR DESCRIPTION
The purpose of this PR is to fully and automatically support the parsing and validation of a json object of variable values referenced by their names into a `VariableValues` object.
This project is using Aeson already so the interface will use the aeson AST for JSON.
The goal is to address #145, #132, and to replace #128 

Schematically, the idea is to follow the generation of the schema by a double tree descending job where we compare the GraphQL's expected type and the JSON's observed value to either return an error or return the expected Haskell/GraphQL value.
For now, the code will reuse the Validation module and the execution module. The actual variables parsing will be done in the Validation module. 

I'm open to any suggestion or help.