### PR TITLE
Improve type safety on operation interpreting

### DIFF
--- a/graphql-wai/src/GraphQL/Wai.hs
+++ b/graphql-wai/src/GraphQL/Wai.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Basic WAI handlers for graphql-api
 module GraphQL.Wai
@@ -15,8 +16,8 @@ import Network.HTTP.Types.Header (hContentType)
 import Network.HTTP.Types.Status (status200, status400)
 
 import GraphQL (interpretAnonymousQuery)
-import GraphQL.API (HasObjectDefinition)
-import GraphQL.Resolver (HasResolver, Handler)
+import GraphQL.API (HasObjectDefinition, Object)
+import GraphQL.Resolver (HasResolver, Handler, OperationResolverConstraint)
 import GraphQL.Value (toValue)
 
 
@@ -27,7 +28,12 @@ import GraphQL.Value (toValue)
 -- If you have a 'Cat' type and a corresponding 'catHandler' then you
 -- can use "toApplication @Cat catHandler".
 toApplication
-  :: forall r. (HasResolver IO r, HasObjectDefinition r)
+  :: forall r typeName interfaces fields.
+  ( HasResolver IO r
+  , r ~ Object typeName interfaces fields
+  , OperationResolverConstraint IO fields typeName interfaces
+  , HasObjectDefinition r
+  )
   => Handler IO r -> Application
 toApplication handler = app
   where

--- a/scripts/hpc-ratchet
+++ b/scripts/hpc-ratchet
@@ -35,7 +35,7 @@ In a just world, this would be a separate config file, or command-line arguments
 Each item represents the number of "things" we are OK with not being covered.
 """
 COVERAGE_TOLERANCE = {
-    ALTERNATIVES: 161,
+    ALTERNATIVES: 160,
     BOOLEANS: 8,
     EXPRESSIONS: 1412,
     LOCAL_DECLS: 13,

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Interface for GraphQL API.
 --
 -- __Note__: This module is highly subject to change. We're still figuring
@@ -27,7 +29,7 @@ import Protolude
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
-import GraphQL.API (HasObjectDefinition(..), SchemaError(..))
+import GraphQL.API (HasObjectDefinition(..), Object, SchemaError(..))
 import GraphQL.Internal.Execution
   ( VariableValues
   , ExecutionError
@@ -51,8 +53,13 @@ import GraphQL.Internal.Output
   )
 import GraphQL.Internal.Schema (Schema)
 import qualified GraphQL.Internal.Schema as Schema
-import GraphQL.Resolver (HasResolver(..), Result(..))
-import GraphQL.Value (Name, Value, pattern ValueObject)
+import GraphQL.Resolver
+  ( HasResolver(..)
+  , OperationResolverConstraint
+  , Result(..)
+  , resolveOperation
+  )
+import GraphQL.Value (Name, Value)
 
 -- | Errors that can happen while processing a query document.
 data QueryError
@@ -85,7 +92,10 @@ instance GraphQLError QueryError where
 
 -- | Execute a GraphQL query.
 executeQuery
-  :: forall api m. (HasResolver m api, Applicative m, HasObjectDefinition api)
+  :: forall api m fields typeName interfaces.
+  ( Object typeName interfaces fields ~ api
+  , OperationResolverConstraint m fields typeName interfaces
+  )
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> QueryDocument VariableValue  -- ^ A validated query document. Build one with 'compileQuery'.
   -> Maybe Name -- ^ An optional name. If 'Nothing', then executes the only operation in the query. If @Just "something"@, executes the query named @"something".
@@ -94,17 +104,14 @@ executeQuery
 executeQuery handler document name variables =
   case getOperation document name variables of
     Left e -> pure (ExecutionFailure (singleError e))
-    Right operation -> toResult <$> resolve @m @api handler (Just operation)
+    Right operation ->
+      toResult
+        <$> resolveOperation @m @fields @typeName @interfaces handler operation
   where
-    toResult (Result errors result) =
-      case result of
-        -- TODO: Prevent this at compile time. Particularly frustrating since
-        -- we *know* that api has an object definition.
-        ValueObject object ->
-          case NonEmpty.nonEmpty errors of
-            Nothing -> Success object
-            Just errs -> PartialSuccess object (map toError errs)
-        v -> ExecutionFailure (singleError (NonObjectResult v))
+    toResult (Result errors object) =
+      case NonEmpty.nonEmpty errors of
+        Nothing -> Success object
+        Just errs -> PartialSuccess object (map toError errs)
 
 -- | Create a GraphQL schema.
 makeSchema :: forall api. HasObjectDefinition api => Either QueryError Schema
@@ -114,7 +121,10 @@ makeSchema = first SchemaError (Schema.makeSchema <$> getDefinition @api)
 --
 -- Compiles then executes a GraphQL query.
 interpretQuery
-  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
+  :: forall api m fields typeName interfaces.
+  ( Object typeName interfaces fields ~ api
+  , OperationResolverConstraint m fields typeName interfaces
+  )
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> Text -- ^ The text of a query document. Will be parsed and then executed.
   -> Maybe Name -- ^ An optional name for the operation within document to run. If 'Nothing', execute the only operation in the document. If @Just "something"@, execute the query or mutation named @"something"@.
@@ -129,7 +139,10 @@ interpretQuery handler query name variables =
 --
 -- Anonymous queries have no name and take no variables.
 interpretAnonymousQuery
-  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
+  :: forall api m fields typeName interfaces.
+  ( Object typeName interfaces fields ~ api
+  , OperationResolverConstraint m fields typeName interfaces
+  )
   => Handler m api -- ^ Handler for the anonymous query.
   -> Text -- ^ The text of the anonymous query. Should defined only a single, unnamed query operation.
   -> m Response -- ^ The result of running the query.

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -2,17 +2,15 @@
 --
 -- Contains everything you need to write handlers for your GraphQL schema.
 module GraphQL.Resolver
-  ( ResolverError(..)
-  , HasResolver(..)
-  , (:<>)(..)
-  , Result(..)
-  , unionValue
+  ( module Export
   ) where
 
-import GraphQL.Internal.Resolver
+import GraphQL.Internal.Resolver as Export
   ( ResolverError(..)
   , HasResolver(..)
+  , OperationResolverConstraint
   , (:<>)(..)
   , Result(..)
   , unionValue
+  , resolveOperation
   )


### PR DESCRIPTION
This is one of a series of PR's I am doing as small improvements that are suggesting on the code itself.

This constraints the resolving of the operation (or the root of the query) to only objects. Removing the unnecessary check that was done checking if the result of the resolving was indeed an object or not.

I want to implement schema introspection and for that I have been reading the code to understand where and how to add it. To be able to handle the `__schema` field, it's necessary a resolver that we are sure that is the entrypoint so we can build up the schema downwards from it. This change makes it possible.