### PR TITLE
Fix issue with inability to parse mandatory types

### DIFF
--- a/src/GraphQL/Internal/Syntax/Parser.hs
+++ b/src/GraphQL/Internal/Syntax/Parser.hs
@@ -212,8 +212,8 @@ directive = AST.Directive
 -- * Type Reference
 
 type_ :: Parser AST.GType
-type_ = AST.TypeList    <$> listType
-    <|> AST.TypeNonNull <$> nonNullType
+type_ = AST.TypeNonNull <$> nonNullType
+    <|> AST.TypeList    <$> listType
     <|> AST.TypeNamed   <$> namedType
     <?> "type_ error!"
 


### PR DESCRIPTION
Prior to this commit:

    λ parseWith (pure mempty) type_ "[B!]!"
    Done "!" (TypeList ...)

With this commit we now have:

    λ parseWith (pure mempty) type_ "[B!]!"
    Done "" (TypeNonNull ...)

The important thing to note here is that previous "[B!]!" was parsed
as a list type (not a non-null type), but all the input was not
consumed as expected.  This means that whatever parser comes after
would start by looking at the exclamation point, which belongs to the
type.